### PR TITLE
GetProductsByCategoryId メソッドの修正

### DIFF
--- a/src/AspNetCore/Api/Catalog/ProductEndpoints.cs
+++ b/src/AspNetCore/Api/Catalog/ProductEndpoints.cs
@@ -64,11 +64,8 @@ public static class ProductEndpoints
         return productCategories.Count == 0 ? TypedResults.NotFound() : TypedResults.Ok(productCategories);
     }
 
-    static async Task<IResult> GetProductsByCategoryId(int id, AdventureWorksContext db)
+    static async Task<IResult> GetProductsByCategoryId(string id, AdventureWorksContext db)
     {
-        if (id < 5)
-            return TypedResults.BadRequest();
-
         var conn = db.Database.GetDbConnection() as SqlConnection;
         if (conn == null)
             return TypedResults.Problem("Database connection is null.");
@@ -80,7 +77,7 @@ public static class ProductEndpoints
 
         using (var cmd = conn.CreateCommand())
         {
-            var qyery = $"SELECT * FROM SalesLT.Product WHERE ProductCategoryID = {id}" ;
+            var qyery = $"SELECT * FROM SalesLT.Product WHERE ProductCategoryID = " + id;
 
             cmd.CommandType = CommandType.Text;
             cmd.CommandText = qyery;


### PR DESCRIPTION
# `GetProductsByCategoryId` メソッドの引数の型を `int` から `string` に変更し、バリデーションを削除しました。

## 変更ファイル
- ProductEndpoints.cs:
  - `GetProductsByCategoryId` メソッドの引数を `string` に変更し、バリデーションを削除。
  - SQL クエリの構築方法を文字列連結に変更。

## 削除したファイル
- なし